### PR TITLE
Clean leading text from request

### DIFF
--- a/src/parseEvent.js
+++ b/src/parseEvent.js
@@ -3,6 +3,14 @@ import {
     parseYouTubeRequest,
 } from './parser'
 
+function cleanRequest(request) {
+    return request
+        // Remove any leading / trailing whitespace
+        .trim()
+        // Remove leading string that may be included when copying from browser
+        .replace("Request URL: ", "");
+}
+
 function isYouTubeRequest(request) {
     if (request.startsWith("https://www.youtube.com/embed/")) {
         return true;
@@ -16,7 +24,7 @@ function isGAMRequest(request) {
 }
 
 function parseRequest(request, truncateValues, ignoreValues) {
-    if (request && request.trim().length > 0) {
+    if (request && request.length > 0) {
         if (isYouTubeRequest(request)) {
             return parseYouTubeRequest(request, truncateValues, ignoreValues)
         } else if (isGAMRequest(request)) {
@@ -37,8 +45,8 @@ function parseEvent(event) {
     const ignoreValues = !includeValues;
 
     return [
-        parseRequest(request1, truncateValues, ignoreValues),
-        parseRequest(request2, truncateValues, ignoreValues),
+        parseRequest(cleanRequest(request1), truncateValues, ignoreValues),
+        parseRequest(cleanRequest(request2), truncateValues, ignoreValues),
     ];
 }
 


### PR DESCRIPTION
## What does this change?

Accept (and clean) URLs with leading whitespace or the string `Request URL: `.

## Why

Sometimes when quickly grabbing URLs from the the devtools I grab too a little whitespace. Or, if you double click the URL and copy you'll also get the `Request URL: ` string at the beginning. This PR cleans these values out so you don't have to do it manually when you copy into the tool.